### PR TITLE
adding readme; fixing asset deploy to GH release

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -43,4 +43,5 @@ echo
 echo "***"
 echo "* Pushing zip file asset to GitHub release."
 echo "***"
-curl -v -X POST -H "Authorization: token $GITHUB_TOKEN" --data-binary @/home/circleci/solrconfig.zip -H "Content-Type: application/octet-stream" "https://uploads.github.com/repos/tulibraries/tul_cob-web-solr/releases/$CIRCLE_TAG/assets?name=tul_cob-web-$CIRCLE_TAG.zip"
+RELEASE_ID=$(curl "https://api.github.com/repos/tulibraries/tul_cob-web-solr/releases/latest" | jq .id)
+curl -v -X POST -H "Authorization: token $GITHUB_TOKEN" --data-binary @/home/circleci/solrconfig.zip -H "Content-Type: application/octet-stream" "https://uploads.github.com/repos/tulibraries/tul_cob-web-solr/releases/$RELEASE_ID/assets?name=tul_cob-web-$CIRCLE_TAG.zip"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# TUL COB Web Content Solr Configurations
+[![CircleCI](https://circleci.com/gh/tulibraries/tul_cob-web-solr.svg?style=svg)](https://circleci.com/gh/tulibraries/tul_cob-web-solr)
+
+These are the Solr configuration files for the TUL Cob (LibrarySearch) web content search & faceting Solr collection.
+
+## Prerequisites
+
+- These configurations are built for Solr 8.1
+- The instructions below presume a SolrCloud multi-node setup (using an external Zookeeper)
+
+## Local Testing / Development
+
+You need a local SolrCloud cluster running to load these into. For example, use the make commands + docker-compose file in https://github.com/tulibraries/ansible-playbook-solrcloud to start a cluster. That repository's makefile includes this set of configurations and collection (funcake) in its `make create-release-collections` and `make create-aliases` commands.
+
+If you want to go through those steps yourself, once you have a working SolrCloud cluster:
+
+1. clone this repository locally & change into the top level directory of the repository
+
+```
+$ git clone https://github.com/tulibraries/tul_cob-web-solr.git
+$ cd funcake-solr
+```
+
+2. zip the contents of this repository *without* the top-level directory
+
+```
+$ zip -r - * > tul_cob-web.zip
+```
+
+3. load the configs zip file into a new SolrCloud ConfigSet (change the solr url to whichever solr you're developing against)
+
+```
+$ curl -X POST --header "Content-Type:application/octet-stream" --data-binary @tul_cob-web.zip "http://localhost:8081/solr/admin/configs?action=UPLOAD&name=tul_cob-web"
+```
+
+4. create a new SolrCloud Collection using that ConfigSet (change the solr url to whichever solr you're developing against)
+
+```
+$ curl "http://localhost:8090/solr/admin/collections?action=CREATE&name=tul_cob-web-1&numShards=1&replicationFactor=2&maxShardsPerNode=1&collection.configName=tul_cob-web"
+```
+
+5. create a new SolrCloud Alias pointing to that Collection (if you want to use an Alias; and change the solr url to whatever solr you're developing against):
+
+```
+$ curl "http://localhost:8090/solr/admin/collections?action=CREATEALIAS&name=tul_cob-web-1-dev&collections=tul_cob-web-1"
+```
+
+## SolrCloud Deployment
+
+All PRs merged into the `master` branch are _not_ deployed anywhere. Only releases are deployed.
+
+### Production
+
+Once the master branch has been adequately tested and reviewed, a release is cut. Upon creating the release tag (generally just an integer), the following occurs:
+1. new ConfigSet of `tul_cob-web-{release-tag}` is created in [Production SolrCloud](https://solrcloud.tul-infra.page);
+2. new Collection of `tul_cob-web-{release-tag}-init` is created in [Production SolrCloud](https://solrcloud.tul-infra.page) w/the requisite ConfigSet (this Collection is largely ignored);
+3. a new QA alias of `tul_cob-web-{release-tag}-qa` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
+3. a new Stage alias of `tul_cob-web-{release-tag}-stage` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
+3. a new Stage alias of `tul_cob-web-{release-tag}-prod` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
+4. and, manually, a full reindex DAG is kicked off from Airflow Production to this new tul_cob-web alias. Upon completion of the reindex, relevant clients are redeployed pointing at their new alias, and *then QA & UAT review occur*.
+
+See the process outlined here: https://github.com/tulibraries/grittyOps/blob/master/services/solrcloud.md
+
+After some time (1-4 days, as needed), the older tul_cob-web collections are manually removed from Prod SolrCloud.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Once the master branch has been adequately tested and reviewed, a release is cut
 2. new Collection of `tul_cob-web-{release-tag}-init` is created in [Production SolrCloud](https://solrcloud.tul-infra.page) w/the requisite ConfigSet (this Collection is largely ignored);
 3. a new QA alias of `tul_cob-web-{release-tag}-qa` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
 3. a new Stage alias of `tul_cob-web-{release-tag}-stage` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
-3. a new Stage alias of `tul_cob-web-{release-tag}-prod` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
+3. a new Production alias of `tul_cob-web-{release-tag}-prod` is created in [Production SolrCloud](https://solrcloud.tul-infra.page), pointing to the init Collection;
 4. and, manually, a full reindex DAG is kicked off from Airflow Production to this new tul_cob-web alias. Upon completion of the reindex, relevant clients are redeployed pointing at their new alias, and *then QA & UAT review occur*.
 
 See the process outlined here: https://github.com/tulibraries/grittyOps/blob/master/services/solrcloud.md

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These are the Solr configuration files for the TUL Cob (LibrarySearch) web conte
 
 ## Local Testing / Development
 
-You need a local SolrCloud cluster running to load these into. For example, use the make commands + docker-compose file in https://github.com/tulibraries/ansible-playbook-solrcloud to start a cluster. That repository's makefile includes this set of configurations and collection (funcake) in its `make create-release-collections` and `make create-aliases` commands.
+You need a local SolrCloud cluster running to load these into. For example, use the make commands + docker-compose file in https://github.com/tulibraries/ansible-playbook-solrcloud to start a cluster. That repository's makefile includes this set of configurations and collection (tul_cob-web) in its `make create-release-collections` and `make create-aliases` commands.
 
 If you want to go through those steps yourself, once you have a working SolrCloud cluster:
 
@@ -18,7 +18,7 @@ If you want to go through those steps yourself, once you have a working SolrClou
 
 ```
 $ git clone https://github.com/tulibraries/tul_cob-web-solr.git
-$ cd funcake-solr
+$ cd tul_cob-web-solr
 ```
 
 2. zip the contents of this repository *without* the top-level directory


### PR DESCRIPTION
What this PR does:
- Adds a REAMDE.md
- Fixes the deploy step to properly look up the release id (which is not the release tag) and use that in the command to attach the new configs zip file as an asset to the new release

No need to immediately cut a new release after this ; can be picked up in the next release after substantive solr config changes have been requested.