### PR TITLE
Remove duplicate searc handler default.

### DIFF
--- a/solrconfig.xml
+++ b/solrconfig.xml
@@ -221,7 +221,7 @@
 
   </requestHandler>
 
-  <requestHandler name="title_search" class="solr.SearchHandler" default="true">
+  <requestHandler name="title_search" class="solr.SearchHandler">
     <!-- default values for query parameters can be specified, these
          will be overridden by parameters in the request
       -->


### PR DESCRIPTION
The search handler default duplicate is causing warnings on solr that could be the cause of and indexing 500 error we are seeing.